### PR TITLE
Refactor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,22 +1,20 @@
 name: test
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
 
 jobs:
   luacheck:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     steps:
     -
       name: Checkout
       uses: actions/checkout@v2
-      with:
-        submodules: 'true'
-    -
-      name: Setup Lua
-      uses: leafo/gh-actions-lua@v10
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
     -
       name: Install Tools
       run: luarocks install luacheck
@@ -26,51 +24,52 @@ jobs:
         luacheck .
 
   test:
+    needs: luacheck
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     strategy:
       matrix:
         lua-version:
-          - "5.1"
-          - "5.2"
-          - "5.3"
-          - "5.4"
-          - "luajit-2.0.5"
-          - "luajit-openresty"
+          - "5.1.:latest"
+          - "5.2.:latest"
+          - "5.3.:latest"
+          - "5.4.:latest"
+          - "lj-v2.1:latest"
     steps:
+    -
+      name: Switch Lua Version
+      run: |
+        lenv -g use ${{ matrix.lua-version }}
+        lua -v || true
     -
       name: Checkout
       uses: actions/checkout@v2
-      with:
-        submodules: 'true'
-    -
-      name: Setup Lua ${{ matrix.lua-version }}
-      uses: leafo/gh-actions-lua@v10
-      with:
-        luaVersion: ${{ matrix.lua-version }}
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
     -
       name: Install
       run: |
-        luarocks make IO_TRUNCATE_COVERAGE=1
+        IO_TRUNCATE_COVERAGE=1 luarocks make
     -
       name: Install Tools
       run: |
-        sudo apt install lcov -y
+        luarocks install testcase
         luarocks install assert
         luarocks install io-fileno
     -
       name: Run Test
       run: |
-        lua ./test/truncate_test.lua
+        testcase ./test/truncate_test.lua
     -
       name: Generate coverage reports
       run: |
         sh ./covgen.sh
     -
-      name: Upload c coverage to Codecov
-      uses: codecov/codecov-action@v3
+      name: Upload C coverage to Codecov
+      uses: codecov/codecov-action@v5
       with:
+        use_oidc: true
+        disable_search: true
         files: ./coverage/lcov.info
         flags: unittests

--- a/covgen.sh
+++ b/covgen.sh
@@ -3,6 +3,6 @@
 set -ex
 
 mkdir -p ./coverage
-lcov -c -d . -o coverage/lcov.info.all
-lcov -r coverage/lcov.info.all '*/include/*' -o coverage/lcov.info
+lcov -c -d . -o coverage/lcov.info
+# lcov -r coverage/lcov.info.all '*/include/*' -o coverage/lcov.info
 # genhtml -o coverage/html coverage/lcov.info

--- a/rockspecs/io-truncate-dev-1.rockspec
+++ b/rockspecs/io-truncate-dev-1.rockspec
@@ -1,3 +1,4 @@
+rockspec_format = "3.0"
 package = "io-truncate"
 version = "dev-1"
 source = {
@@ -12,19 +13,22 @@ description = {
 dependencies = {
     "lua >= 5.1",
 }
+build_dependencies = {
+    "luarocks-build-hooks >= 0.8.0",
+}
 build = {
-    type = "make",
-    build_variables = {
-        CFLAGS = "$(CFLAGS)",
-        WARNINGS = "-Wall -Wno-trigraphs -Wmissing-field-initializers -Wreturn-type -Wmissing-braces -Wparentheses -Wno-switch -Wunused-function -Wunused-label -Wunused-parameter -Wunused-variable -Wunused-value -Wuninitialized -Wunknown-pragmas -Wshadow -Wsign-compare",
-        CPPFLAGS = "-I$(LUA_INCDIR)",
-        LDFLAGS = "$(LIBFLAG)",
-        LIB_EXTENSION = "$(LIB_EXTENSION)",
-        IO_TRUNCATE_COVERAGE = "$(IO_TRUNCATE_COVERAGE)",
+    type = "hooks",
+    before_build = "$(extra-vars)",
+    extra_variables = {
+        CFLAGS = "-Wall -Wno-trigraphs -Wmissing-field-initializers -Wreturn-type -Wmissing-braces -Wparentheses -Wno-switch -Wunused-function -Wunused-label -Wunused-parameter -Wunused-variable -Wunused-value -Wuninitialized -Wunknown-pragmas -Wshadow -Wsign-compare",
     },
-    install_variables = {
-        LIB_EXTENSION = "$(LIB_EXTENSION)",
-        INST_LIBDIR = "$(LIBDIR)/io/",
-        INST_LUADIR = "$(LUADIR)",
+    conditional_variables = {
+        IO_TRUNCATE_COVERAGE = {
+            CFLAGS = "--coverage",
+            LIBFLAG = "--coverage",
+        },
+    },
+    modules = {
+        ["io.truncate"] = "src/truncate.c",
     },
 }

--- a/src/truncate.c
+++ b/src/truncate.c
@@ -21,6 +21,7 @@
  */
 
 #include <errno.h>
+#include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/test/truncate_test.lua
+++ b/test/truncate_test.lua
@@ -1,8 +1,9 @@
+local testcase = require('testcase')
 local assert = require('assert')
 local fileno = require('io.fileno')
 local truncate = require('io.truncate')
 
-local function test_truncate_file()
+function testcase.truncate_file()
     -- confirm initial length
     local f = assert(io.tmpfile())
     assert.equal(f:seek('end'), 0)
@@ -15,9 +16,8 @@ local function test_truncate_file()
     assert(truncate(f, 5))
     assert.equal(f:seek('end'), 5)
 end
-test_truncate_file()
 
-local function test_truncate_fd()
+function testcase.truncate_fd()
     -- confirm initial length
     local f = assert(io.tmpfile())
     assert.equal(f:seek('end'), 0)
@@ -36,9 +36,8 @@ local function test_truncate_fd()
     assert.is_false(ok)
     assert.re_match(err, 'bad file', 'i')
 end
-test_truncate_fd()
 
-local function test_truncate_filename()
+function testcase.truncate_filename()
     -- confirm initial length
     local tmpfile = os.tmpname()
     local f = assert(io.open(tmpfile, 'w+'))
@@ -58,9 +57,8 @@ local function test_truncate_filename()
     assert.is_false(ok)
     assert.re_match(err, 'no .* file', 'i')
 end
-test_truncate_filename()
 
-local function test_truncate_with_invalid_arguments()
+function testcase.truncate_with_invalid_arguments()
     -- test that throw error if first argument is invalid
     local err = assert.throws(truncate, {}, 10)
     assert.match(err, 'bad argument .* string, integer or file', false)
@@ -69,5 +67,3 @@ local function test_truncate_with_invalid_arguments()
     err = assert.throws(truncate, 'test.txt', {})
     assert.match(err, 'bad argument .*number expected', false)
 end
-test_truncate_with_invalid_arguments()
-


### PR DESCRIPTION
This pull request updates the testing and build workflow to use a containerized Lua CI environment, modernizes the rockspec build configuration, and refactors the test suite to use the `testcase` framework. The changes streamline CI setup, improve test reporting, and update coverage and dependency management.

**CI/CD Workflow Improvements:**

* Updated `.github/workflows/test.yml` to use the `ghcr.io/mah0x211/lua-ci:latest` container for both linting and testing, simplifying environment setup and ensuring consistent builds. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L3-L19) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R27-R73)
* Modified the test matrix to use new Lua version tags and added a step to switch Lua versions with `lenv`.
* Upgraded Codecov action to v5 and enabled OIDC authentication for secure uploads.

**Build and Dependency Management:**

* Updated `rockspecs/io-truncate-dev-1.rockspec` to use `rockspec_format = "3.0"`, switched build type to `hooks`, added `luarocks-build-hooks` as a build dependency, and improved build variable handling for code coverage. [[1]](diffhunk://#diff-653f23d3ed5c7d90e0b9c935f9b21159522a74957f9a048c1a7c4866eb99a723R1) [[2]](diffhunk://#diff-653f23d3ed5c7d90e0b9c935f9b21159522a74957f9a048c1a7c4866eb99a723R16-R32)

**Test Suite Refactoring:**

* Refactored `test/truncate_test.lua` to use the `testcase` framework instead of standalone function calls, improving test structure and integration with the new CI setup. [[1]](diffhunk://#diff-353caa360ee2f8ab2c1f1a8301dc67447832f57e101a745aac7cabf9926fbaa5R1-R6) [[2]](diffhunk://#diff-353caa360ee2f8ab2c1f1a8301dc67447832f57e101a745aac7cabf9926fbaa5L18-R20) [[3]](diffhunk://#diff-353caa360ee2f8ab2c1f1a8301dc67447832f57e101a745aac7cabf9926fbaa5L39-R40) [[4]](diffhunk://#diff-353caa360ee2f8ab2c1f1a8301dc67447832f57e101a745aac7cabf9926fbaa5L61-R61) [[5]](diffhunk://#diff-353caa360ee2f8ab2c1f1a8301dc67447832f57e101a745aac7cabf9926fbaa5L72-L73)
* Updated test execution in the workflow to use `testcase` instead of direct Lua execution.

**Coverage Generation:**

* Simplified `covgen.sh` to generate coverage data with a single `lcov` command, commenting out filtering and HTML report generation for now.

**Minor Codebase Maintenance:**

* Added missing `#include <stdio.h>` in `src/truncate.c` for completeness.